### PR TITLE
Parse queries simpler, using a new flag

### DIFF
--- a/azure-kusto-data/Cargo.toml
+++ b/azure-kusto-data/Cargo.toml
@@ -13,22 +13,22 @@ keywords = ["sdk", "azure", "kusto", "azure-data-explorer"]
 categories = ["api-bindings"]
 
 [dependencies]
-arrow = { version = "28.0.0", optional = true }
-azure_core = { version = "0.7.0", features = [
+arrow = { version = "31.0.0", optional = true }
+azure_core = { version = "0.8.0", features = [
     "enable_reqwest",
     "enable_reqwest_gzip",
 ] }
-azure_identity = { version = "0.8.0" }
-async-trait = "0.1.59"
+azure_identity = "0.9.0"
+async-trait = "0.1.63"
 async-convert = "1.0.0"
 bytes = "1.3.0"
 futures = "0.3.25"
-serde = { version = "1.0.148", features = ["derive"] }
-serde_json = "1.0.89"
-serde_with = { version = "2.1.0", features = ["json"] }
-thiserror = "1.0.37"
-hashbrown = "0.13.1"
-regex = "1.7.0"
+serde = { version = "1.0.152", features = ["derive"] }
+serde_json = "1.0.91"
+serde_with = { version = "2.2.0", features = ["json"] }
+thiserror = "1.0.38"
+hashbrown = { version = "0.13.2", features = ["serde"] }
+regex = "1.7.1"
 time = { version = "0.3.17", features = [
     "serde",
     "parsing",
@@ -36,18 +36,18 @@ time = { version = "0.3.17", features = [
     "macros",
     "serde-well-known",
 ] }
-derive_builder = "0.12"
-once_cell = "1.16.0"
+derive_builder = "0.12.0"
+once_cell = "1.17.0"
 
 [dev-dependencies]
-arrow = { version = "28.0.0", features = ["prettyprint"] }
+arrow = { version = "31.0.0", features = ["prettyprint"] }
 dotenv = "0.15.0"
 env_logger = "0.10.0"
-tokio = { version = "1.22.0", features = ["macros"] }
+tokio = { version = "1.24.2", features = ["macros"] }
 oauth2 = "4.3.0"
 criterion = "0.4.0"
-clap = { version = "4", features = ["derive", "env"] }
-decimal = "2.0.0"
+clap = { version = "4.1.1", features = ["derive", "env"] }
+decimal = "2.1.0"
 uuid = { version = "1.2.2", features = [ "serde"] }
 
 [features]

--- a/azure-kusto-data/src/error.rs
+++ b/azure-kusto-data/src/error.rs
@@ -47,6 +47,10 @@ pub enum Error {
     /// Errors raised when the query is invalid
     #[error("Invalid query: {0}")]
     QueryError(String),
+
+    /// Errors raised for IO operations
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
 }
 
 /// Errors raised when an invalid argument or option is provided.

--- a/azure-kusto-data/src/operations/async_deserializer.rs
+++ b/azure-kusto-data/src/operations/async_deserializer.rs
@@ -1,104 +1,57 @@
-use futures::io::BufReader;
-use futures::{pin_mut, stream, AsyncRead, AsyncReadExt, Stream, TryStreamExt};
-use serde::de::DeserializeOwned;
 use std::io;
-use std::pin::Pin;
+use std::io::Read;
+
+use futures::{AsyncBufRead, AsyncBufReadExt, AsyncReadExt, stream, Stream};
+use serde::de::DeserializeOwned;
 
 // TODO: Find a crate that does this better / move this into another crate
-
-async fn read_skipping_ws(reader: impl AsyncRead + Send) -> io::Result<u8> {
-    pin_mut!(reader);
-    loop {
-        let mut byte = 0u8;
-        reader.read_exact(std::slice::from_mut(&mut byte)).await?;
-        print!("{}", byte as char);
-        if !byte.is_ascii_whitespace() {
-            return Ok(byte);
-        }
-    }
-}
 
 fn invalid_data(msg: &str) -> io::Error {
     io::Error::new(io::ErrorKind::InvalidData, msg)
 }
 
-const BUFFER_SIZE: usize = 4096;
+async fn deserialize_single<T: DeserializeOwned>(
+    reader: &mut (impl AsyncBufRead + Send  + Unpin),
+    buf: &mut Vec<u8>,
+) -> io::Result<T> {
+    buf.resize(0, 0);
+    let size = reader.read_until(b'\n', buf).await?;
+    return Ok(serde_json::from_slice(&buf[..size-1])?);
+}
 
-async fn deserialize_single<T: DeserializeOwned, R: AsyncRead + Send>(
-    reader: R,
-) -> io::Result<(T, Vec<u8>)> {
-    let mut vec = Vec::with_capacity(BUFFER_SIZE);
-    let mut buf = [0; BUFFER_SIZE];
-    let mut leftover = Vec::with_capacity(BUFFER_SIZE);
+async fn read_byte(reader: &mut (impl AsyncBufRead + Send  + Unpin)) -> io::Result<u8> {
+    let mut buf = [0u8; 1];
+    reader.read_exact(&mut buf).await?;
+    Ok(buf[0])
+}
 
-    pin_mut!(reader);
-
-    loop {
-        let size = reader.read(&mut buf).await?;
-        print!("{}", String::from_utf8_lossy(&buf[..size]));
-        vec.extend_from_slice(&buf[..size]);
-
-        let res = serde_json::from_slice::<T>(vec.as_slice());
-
-        match res {
-            Ok(t) => return Ok((t, leftover)),
-            Err(e) => {
-                if e.is_syntax() {
-                    let i = e.column() - 1;
-                    leftover.extend_from_slice(&vec[i..]);
-                    return Ok((serde_json::from_slice::<T>(&vec[..i])?, leftover));
-                } else if e.is_eof() {
-                    continue;
-                }
-                return Err(e.into());
+async fn yield_next_obj<T: DeserializeOwned>(
+    reader: &mut (impl AsyncBufRead + Send  + Unpin),
+    buf: &mut Vec<u8>,
+) -> Result<Option<T>, io::Error> {
+    Ok(Some(match read_byte(reader).await? {
+        b'[' => {
+            let newline = read_byte(reader).await?;
+            if newline != b'\n' {
+                return Err(invalid_data(&format!("Expected newline after opening '[', found {:?}", newline)));
             }
+            deserialize_single(reader, buf).await?
         }
+        b',' => deserialize_single(reader, buf).await?,
+        b']' => return Ok(None),
+        b => return Err(invalid_data(&format!("Unexpected byte {:?}", b))),
     }
+    ))
 }
 
-async fn yield_next_obj<T: DeserializeOwned, R: AsyncRead + Send>(
-    reader: R,
-    first_time: bool,
-) -> io::Result<Option<(T, Vec<u8>)>> {
-    pin_mut!(reader);
+pub fn iter_results<T: DeserializeOwned>(
+    reader: (impl AsyncBufRead + Send  + Unpin),
+) -> impl Stream<Item=Result<T, io::Error>> {
+    let buf = vec![];
 
-    match read_skipping_ws(&mut reader).await? {
-        b'[' if first_time => {
-            let (result, leftover) = deserialize_single(&mut reader).await?;
-            Ok(Some((result, leftover)))
-        }
-        b',' if !first_time => {
-            let (result, leftover) = deserialize_single(&mut reader).await?;
-            Ok(Some((result, leftover)))
-        }
-        b']' if !first_time => Ok(None),
-        c => Err(invalid_data(&format!("Unexpected char {}", c as char))),
-    }
-}
-
-pub fn iter_results<T: DeserializeOwned, R: AsyncRead + Send + 'static>(
-    reader: R,
-) -> impl Stream<Item = Result<T, io::Error>> {
-    stream::try_unfold(
-        (
-            Box::pin(BufReader::new(reader)) as Pin<Box<dyn AsyncRead + Send>>,
-            true,
-        ),
-        |(mut reader, first_time)| async move {
-            let result = yield_next_obj::<T, _>(reader.as_mut(), first_time).await?;
-            Ok(result.map(|(result, leftover)| {
-                (
-                    result,
-                    (
-                        Box::pin(
-                            stream::iter(vec![Ok(leftover.into_iter())])
-                                .into_async_read()
-                                .chain(reader),
-                        ) as Pin<Box<dyn AsyncRead + Send>>,
-                        false,
-                    ),
-                )
-            }))
-        },
-    )
+    stream::try_unfold((buf, reader),  move |(mut buf, mut reader)| async {
+        yield_next_obj(&mut reader, &mut buf).await.map(|r| r.map(|obj| {
+            (obj, (buf, reader))
+        }))
+    })
 }

--- a/azure-kusto-data/src/operations/async_deserializer.rs
+++ b/azure-kusto-data/src/operations/async_deserializer.rs
@@ -1,7 +1,7 @@
 use std::io;
 use std::io::Read;
 
-use futures::{AsyncBufRead, AsyncBufReadExt, AsyncReadExt, stream, Stream};
+use futures::{stream, AsyncBufRead, AsyncBufReadExt, AsyncReadExt, Stream};
 use serde::de::DeserializeOwned;
 
 // TODO: Find a crate that does this better / move this into another crate
@@ -11,47 +11,49 @@ fn invalid_data(msg: &str) -> io::Error {
 }
 
 async fn deserialize_single<T: DeserializeOwned>(
-    reader: &mut (impl AsyncBufRead + Send  + Unpin),
+    reader: &mut (impl AsyncBufRead + Send + Unpin),
     buf: &mut Vec<u8>,
 ) -> io::Result<T> {
     buf.resize(0, 0);
     let size = reader.read_until(b'\n', buf).await?;
-    return Ok(serde_json::from_slice(&buf[..size-1])?);
+    return Ok(serde_json::from_slice(&buf[..size - 1])?);
 }
 
-async fn read_byte(reader: &mut (impl AsyncBufRead + Send  + Unpin)) -> io::Result<u8> {
+async fn read_byte(reader: &mut (impl AsyncBufRead + Send + Unpin)) -> io::Result<u8> {
     let mut buf = [0u8; 1];
     reader.read_exact(&mut buf).await?;
     Ok(buf[0])
 }
 
 async fn yield_next_obj<T: DeserializeOwned>(
-    reader: &mut (impl AsyncBufRead + Send  + Unpin),
+    reader: &mut (impl AsyncBufRead + Send + Unpin),
     buf: &mut Vec<u8>,
 ) -> Result<Option<T>, io::Error> {
     Ok(Some(match read_byte(reader).await? {
         b'[' => {
             let newline = read_byte(reader).await?;
             if newline != b'\n' {
-                return Err(invalid_data(&format!("Expected newline after opening '[', found {:?}", newline)));
+                return Err(invalid_data(&format!(
+                    "Expected newline after opening '[', found {:?}",
+                    newline
+                )));
             }
             deserialize_single(reader, buf).await?
         }
         b',' => deserialize_single(reader, buf).await?,
         b']' => return Ok(None),
         b => return Err(invalid_data(&format!("Unexpected byte {:?}", b))),
-    }
-    ))
+    }))
 }
 
 pub fn iter_results<T: DeserializeOwned>(
-    reader: (impl AsyncBufRead + Send  + Unpin),
-) -> impl Stream<Item=Result<T, io::Error>> {
+    reader: (impl AsyncBufRead + Send + Unpin),
+) -> impl Stream<Item = Result<T, io::Error>> {
     let buf = vec![];
 
-    stream::try_unfold((buf, reader),  move |(mut buf, mut reader)| async {
-        yield_next_obj(&mut reader, &mut buf).await.map(|r| r.map(|obj| {
-            (obj, (buf, reader))
-        }))
+    stream::try_unfold((buf, reader), move |(mut buf, mut reader)| async {
+        yield_next_obj(&mut reader, &mut buf)
+            .await
+            .map(|r| r.map(|obj| (obj, (buf, reader))))
     })
 }

--- a/azure-kusto-data/src/operations/async_deserializer.rs
+++ b/azure-kusto-data/src/operations/async_deserializer.rs
@@ -14,7 +14,7 @@ async fn deserialize_single<T: DeserializeOwned>(
     reader: &mut (impl AsyncBufRead + Send + Unpin),
     buf: &mut Vec<u8>,
 ) -> io::Result<T> {
-    buf.resize(0, 0);
+    buf.clear();
     let size = reader.read_until(b'\n', buf).await?;
     return Ok(serde_json::from_slice(&buf[..size - 1])?);
 }

--- a/azure-kusto-data/src/operations/query.rs
+++ b/azure-kusto-data/src/operations/query.rs
@@ -107,15 +107,14 @@ impl QueryRunner {
         let reader = pinned_stream
             .map_err(|e| std::io::Error::new(ErrorKind::Other, e))
             .into_async_read();
-        Ok(async_deserializer::iter_results::<V2QueryResult, _>(
-            reader,
-        ).map_err(|e| (*e.into_inner().expect("Unexpected error from async_deserializer - please report this issue to the Kusto team").downcast::<azure_core::error::Error>().expect("Unexpected error from async_deserializer - please report this issue to the Kusto team")).into()  ))
+
+        Ok(async_deserializer::iter_results(reader).map_err(Error::from))
     }
 }
 
 impl IntoFuture for V1QueryRunner {
-    type IntoFuture = V1QueryRun;
     type Output = Result<KustoResponseDataSetV1>;
+    type IntoFuture = V1QueryRun;
 
     fn into_future(self) -> V1QueryRun {
         Box::pin(async {
@@ -129,8 +128,8 @@ impl IntoFuture for V1QueryRunner {
 }
 
 impl IntoFuture for V2QueryRunner {
-    type IntoFuture = V2QueryRun;
     type Output = Result<KustoResponseDataSetV2>;
+    type IntoFuture = V2QueryRun;
 
     fn into_future(self) -> V2QueryRun {
         Box::pin(async {
@@ -144,8 +143,8 @@ impl IntoFuture for V2QueryRunner {
 }
 
 impl IntoFuture for QueryRunner {
-    type IntoFuture = QueryRun;
     type Output = Result<KustoResponse>;
+    type IntoFuture = QueryRun;
 
     fn into_future(self) -> QueryRun {
         let this = self.clone();
@@ -541,7 +540,7 @@ pub fn prepare_request(url: Url, http_method: Method) -> Request {
         "Kusto.Rust.Client:{}",
         env!("CARGO_PKG_VERSION"),
     )));
-    request.insert_header("Connection", "Keep-Alive");
+    request.insert_header("connection", "Keep-Alive");
     request
 }
 

--- a/azure-kusto-data/src/request_options.rs
+++ b/azure-kusto-data/src/request_options.rs
@@ -1,9 +1,9 @@
 //! Request options for the Azure Data Explorer Client.
 
 use crate::types::{KustoDateTime, KustoDuration};
+use hashbrown::HashMap;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
-use hashbrown::HashMap;
 
 /// Controls the hot or cold cache for the scope of the query.
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -169,7 +169,7 @@ pub struct RequestOptions {
     pub truncation_max_size: Option<i64>,
     /// Validates user's permissions to perform the query and doesn't run the query itself.
     pub validate_permissions: Option<bool>,
-    #[builder(default = "Some(true)" )]
+    #[builder(default = "Some(true)")]
     results_v2_newlines_between_frames: Option<bool>,
     /// Additional options to be passed to the service.
     #[serde(flatten)]

--- a/azure-kusto-data/src/request_options.rs
+++ b/azure-kusto-data/src/request_options.rs
@@ -3,6 +3,7 @@
 use crate::types::{KustoDateTime, KustoDuration};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
+use hashbrown::HashMap;
 
 /// Controls the hot or cold cache for the scope of the query.
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -168,4 +169,9 @@ pub struct RequestOptions {
     pub truncation_max_size: Option<i64>,
     /// Validates user's permissions to perform the query and doesn't run the query itself.
     pub validate_permissions: Option<bool>,
+    #[builder(default = "Some(true)" )]
+    results_v2_newlines_between_frames: Option<bool>,
+    /// Additional options to be passed to the service.
+    #[serde(flatten)]
+    pub additional: HashMap<String, String>,
 }


### PR DESCRIPTION
Using results_v2_newlines_between_frames, we can parse queries much simpler and faster