### PR TITLE
Hiding missing docs warning from release

### DIFF
--- a/azure-kusto-data/src/client_details.rs
+++ b/azure-kusto-data/src/client_details.rs
@@ -1,3 +1,5 @@
+#![allow(missing_docs)]
+
 use std::borrow::Cow;
 
 use once_cell::sync::Lazy;


### PR DESCRIPTION
I just would like to hide this warning 'cause it's annoying to see warnings in a crates.io release. This kind of warning should be only visible for developers.