### PR TITLE
Update to arrow crates to fix `cargo test` compile failure.

### DIFF
--- a/azure-kusto-data/Cargo.toml
+++ b/azure-kusto-data/Cargo.toml
@@ -13,8 +13,8 @@ keywords = ["sdk", "azure", "kusto", "azure-data-explorer"]
 categories = ["api-bindings"]
 
 [dependencies]
-arrow-array = { version = "50.0.0", optional = true }
-arrow-schema = { version = "50.0.0", optional = true }
+arrow-array = { version = "55.0.0", optional = true }
+arrow-schema = { version = "55.0.0", optional = true }
 azure_core = { version = "0.19.0", features = [
     "enable_reqwest",
     "enable_reqwest_gzip",
@@ -41,7 +41,7 @@ derive_builder = "0.12"
 once_cell = "1"
 
 [dev-dependencies]
-arrow = { version = "50.0.0", features = ["prettyprint"] }
+arrow = { version = "55.0.0", features = ["prettyprint"] }
 dotenv = "0.15.0"
 env_logger = "0.10.0"
 tokio = { version = "1.25.0", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
`cargo test` is broken.
Fails to compile with errors in the arrow-arith crate.
Update all arrow crates from 50.0.0 to 55.0.0 resolves this issue.
Addresses Issue https://github.com/Azure/azure-kusto-rust/issues/38