### PR TITLE
Codesmon/auth0.21

### DIFF
--- a/azure-kusto-data/Cargo.toml
+++ b/azure-kusto-data/Cargo.toml
@@ -15,11 +15,11 @@ categories = ["api-bindings"]
 [dependencies]
 arrow-array = { version = "55.0.0", optional = true }
 arrow-schema = { version = "55.0.0", optional = true }
-azure_core = { version = "0.19.0", features = [
+azure_core = { version = "0.21.0", features = [
     "enable_reqwest",
     "enable_reqwest_gzip",
 ] }
-azure_identity = "0.19.0"
+azure_identity = "0.21.0"
 async-trait = "0.1.64"
 async-convert = "1.0.0"
 bytes = "1.4"

--- a/azure-kusto-data/examples/management.rs
+++ b/azure-kusto-data/examples/management.rs
@@ -1,5 +1,6 @@
 use azure_kusto_data::prelude::*;
 use std::error::Error;
+use azure_core::Url;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
@@ -21,8 +22,8 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         std::env::var("AZURE_CLIENT_SECRET").expect("Set env variable AZURE_CLIENT_SECRET first!");
     let authority_id =
         std::env::var("AZURE_TENANT_ID").expect("Set env variable AZURE_TENANT_ID first!");
-
-    let kcsb = ConnectionString::with_application_auth(
+    
+        let kcsb = ConnectionString::with_application_auth(
         service_url,
         client_id,
         client_secret,

--- a/azure-kusto-data/examples/query.rs
+++ b/azure-kusto-data/examples/query.rs
@@ -6,6 +6,7 @@ use futures::{pin_mut, TryStreamExt};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::error::Error;
+use azure_core::Url;
 
 /// Simple program to greet a person
 #[derive(Parser, Debug, Clone)]

--- a/azure-kusto-data/src/connection_string.rs
+++ b/azure-kusto-data/src/connection_string.rs
@@ -204,8 +204,6 @@ pub enum ConnectionStringAuth {
     },
     /// Application - uses the application client id and key to authenticate.
     Application {
-        /// The authority or tenant id to use.
-        // authority_host: Url,
         /// The application client id to use.
         client_id: String,
         /// The application key to use.
@@ -228,8 +226,6 @@ pub enum ConnectionStringAuth {
     ManagedIdentity {
         /// An optional user id to use. If not specified, system-based MSI is used.
         user_id: Option<String>,
-        /// The authority or tenant id to use.
-        // authority_host: Url,
         /// The application client id to use.
         client_id: String,
         /// The EntraId tenant id to use.
@@ -328,7 +324,6 @@ impl ConnectionStringAuth {
             )),
             ConnectionStringAuth::ManagedIdentity { 
                 user_id,
-                // authority_host,
                 tenant_id,
                 client_id,
                 client_authority,
@@ -376,7 +371,6 @@ impl ConnectionStringAuth {
                 time_to_live,
             }),
             ConnectionStringAuth::Application {
-                // authority_host,
                 client_id,
                 client_secret,
                 client_authority,
@@ -389,14 +383,12 @@ impl ConnectionStringAuth {
             )),
             ConnectionStringAuth::ApplicationCertificate { .. } => unimplemented!(),
             ConnectionStringAuth::ManagedIdentity { user_id ,
-                // authority_host,
                 client_id,
                 tenant_id,
                 client_authority,} => {
                 if let Some(user_id) = user_id {
                     Arc::new(WorkloadIdentityCredential::new(             
                         azure_core::new_http_client(),
-                        // authority_host,
                         Url::parse("https://login.microsoftonline.com").unwrap(),
                         tenant_id,
                         client_id,
@@ -404,7 +396,6 @@ impl ConnectionStringAuth {
                 } else {
                     Arc::new(WorkloadIdentityCredential::new(            
                         azure_core::new_http_client(),
-                        // authority_host,
                         Url::parse("https://login.microsoftonline.com").unwrap(),
                         tenant_id,
                         client_id,

--- a/azure-kusto-data/src/connection_string.rs
+++ b/azure-kusto-data/src/connection_string.rs
@@ -386,17 +386,19 @@ impl ConnectionStringAuth {
                 client_id,
                 tenant_id,
                 client_authority,} => {
+                    
+                let authority_host: Url = Url::parse("https://login.microsoftonline.com").unwrap();
                 if let Some(user_id) = user_id {
                     Arc::new(WorkloadIdentityCredential::new(             
                         azure_core::new_http_client(),
-                        Url::parse("https://login.microsoftonline.com").unwrap(),
+                        authority_host,
                         tenant_id,
                         client_id,
                         user_id))
                 } else {
                     Arc::new(WorkloadIdentityCredential::new(            
                         azure_core::new_http_client(),
-                        Url::parse("https://login.microsoftonline.com").unwrap(),
+                        authority_host,
                         tenant_id,
                         client_id,
                         String::new(),))
@@ -861,7 +863,6 @@ impl ConnectionString {
                 client_id: client_id.into(),
                 client_secret: client_secret.into(),
                 client_authority: client_authority.into(),
-                // authority_host: authority_host.into(),
             },
             application: None,
             user: None,

--- a/azure-kusto-ingest/Cargo.toml
+++ b/azure-kusto-ingest/Cargo.toml
@@ -8,10 +8,10 @@ edition = "2021"
 [dependencies]
 azure-kusto-data = { path = "../azure-kusto-data", default-features = false }
 # Azure SDK for Rust crates versions must be kept in sync
-azure_core = "0.19"
-azure_storage = "0.19"
-azure_storage_blobs = "0.19"
-azure_storage_queues = "0.19"
+azure_core = "0.21"
+azure_storage = "0.21"
+azure_storage_blobs = "0.21"
+azure_storage_queues = "0.21"
 
 async-lock = "3"
 rand = "0.8"


### PR DESCRIPTION
Moved all the azure_* crates to version 0.21, the highest version available for all the packages.
Some code changes required, all tests pass.
Addresses Issue https://github.com/Azure/azure-kusto-rust/issues/36 but we cannot update to the latest version (0.24) as not all of the azure_* crates have been maintained and updated themeselves.